### PR TITLE
Remove dispatch on FT

### DIFF
--- a/src/Thermodynamics.jl
+++ b/src/Thermodynamics.jl
@@ -67,7 +67,7 @@ include("printing.jl")
 @inline print_warning() = false
 
 # Default phase partition for dry air
-@inline q_pt_0(::Type{FT}) where {FT} = PhasePartition(FT(0), FT(0), FT(0))
+@inline q_pt_0(::APS{FT}) where {FT} = PhasePartition(FT(0), FT(0), FT(0))
 
 @inline solution_type() = RS.CompactSolution()
 include("DataCollection.jl")

--- a/src/air_dry_adiabatic.jl
+++ b/src/air_dry_adiabatic.jl
@@ -26,10 +26,10 @@ for an isentropic process: `p = p₀ * (1 - Φ/(θ * cₚ))^(cₚ/R)`, where `p�
 """
 @inline function air_pressure_given_θ(
     param_set::APS,
-    θ::FT,
-    Φ::FT,
+    θ,
+    Φ,
     ::DryAdiabaticProcess,
-) where {FT <: Real}
+)
     p0 = TP.p_ref_theta(param_set)
     _R_d = TP.R_d(param_set)
     _cp_d = TP.cp_d(param_set)
@@ -49,15 +49,9 @@ The pressure is computed using the isentropic relation: `p = p∞ * (T/T∞)^(1/
 where `κ = R/cₚ` is the ratio of the gas constant to the isobaric specific heat capacity
 of dry air.
 """
-@inline function air_pressure(
-    param_set::APS,
-    T::FT,
-    T∞::FT,
-    p∞::FT,
-    ::DryAdiabaticProcess,
-) where {FT <: Real}
+@inline function air_pressure(param_set::APS, T, T∞, p∞, ::DryAdiabaticProcess)
     _kappa_d = TP.kappa_d(param_set)
-    return p∞ * (T / T∞)^(FT(1) / _kappa_d)
+    return p∞ * (T / T∞)^(1 / _kappa_d)
 end
 
 """
@@ -72,12 +66,7 @@ The temperature is computed using the definition of the dry potential temperatur
 `T = θ * (p/p₀)^(R/cₚ)`, where `p₀` is the reference pressure, `R` is the gas constant of dry air,
 and `cₚ` is the isobaric specific heat capacity of dry air.
 """
-@inline function air_temperature(
-    param_set::APS,
-    p::FT,
-    θ::FT,
-    ::DryAdiabaticProcess,
-) where {FT <: Real}
+@inline function air_temperature(param_set::APS, p, θ, ::DryAdiabaticProcess)
     _R_d = TP.R_d(param_set)
     _cp_d = TP.cp_d(param_set)
     p0 = TP.p_ref_theta(param_set)

--- a/src/air_energies.jl
+++ b/src/air_energies.jl
@@ -31,9 +31,9 @@ When `q` is not provided, the results are for dry air.
 """
 @inline function internal_energy(
     param_set::APS,
-    T::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
-) where {FT <: Real}
+    T,
+    q::PhasePartition = q_pt_0(param_set),
+)
     q_vap = vapor_specific_humidity(q)
     q_dry = 1 - q.tot
 
@@ -53,7 +53,7 @@ The dry air internal energy, given
  - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
 """
-@inline function internal_energy_dry(param_set::APS, T::FT) where {FT <: Real}
+@inline function internal_energy_dry(param_set::APS, T)
     T_0 = TP.T_0(param_set)
     cv_d = TP.cv_d(param_set)
     R_d = TP.R_d(param_set)
@@ -68,7 +68,7 @@ The water vapor internal energy, given
  - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
 """
-@inline function internal_energy_vapor(param_set::APS, T::FT) where {FT <: Real}
+@inline function internal_energy_vapor(param_set::APS, T)
     T_0 = TP.T_0(param_set)
     cv_v = TP.cv_v(param_set)
     e_int_v0 = TP.e_int_v0(param_set)
@@ -84,10 +84,7 @@ The liquid water internal energy, given
  - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
 """
-@inline function internal_energy_liquid(
-    param_set::APS,
-    T::FT,
-) where {FT <: Real}
+@inline function internal_energy_liquid(param_set::APS, T)
     T_0 = TP.T_0(param_set)
     cv_l = TP.cv_l(param_set)
 
@@ -102,7 +99,7 @@ The ice internal energy, given
  - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
 """
-@inline function internal_energy_ice(param_set::APS, T::FT) where {FT <: Real}
+@inline function internal_energy_ice(param_set::APS, T)
     T_0 = TP.T_0(param_set)
     cv_i = TP.cv_i(param_set)
     e_int_i0 = TP.e_int_i0(param_set)
@@ -125,18 +122,18 @@ given
 """
 @inline function internal_energy_sat(
     param_set::APS,
-    T::FT,
-    ρ::FT,
-    q_tot::FT,
+    T,
+    ρ,
+    q_tot,
     ::Type{phase_type},
-    q_pt::PhasePartition{FT} = PhasePartition_equil(
+    q_pt::PhasePartition = PhasePartition_equil(
         param_set,
         T,
         ρ,
         q_tot,
         phase_type,
     ),
-) where {FT <: Real, phase_type <: ThermodynamicState}
+) where {phase_type <: ThermodynamicState}
     return internal_energy(param_set, T, q_pt)
 end
 @inline internal_energy_sat(param_set, T, ρ, q_tot, phase_type) =
@@ -160,11 +157,11 @@ When `q` is not provided, the results are for dry air.
 """
 @inline function total_energy(
     param_set::APS,
-    e_kin::FT,
-    e_pot::FT,
-    T::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
-) where {FT <: Real}
+    e_kin,
+    e_pot,
+    T,
+    q::PhasePartition = q_pt_0(param_set),
+)
     return internal_energy(param_set, T, q) + e_pot + e_kin
 end
 
@@ -180,7 +177,7 @@ The specific enthalpy, given
 
 This method is deprecated and will be removed in a future release.
 """
-@inline function specific_enthalpy(e_int::FT, R_m::FT, T::FT) where {FT <: Real}
+@inline function specific_enthalpy(e_int, R_m, T)
     return e_int + R_m * T
 end
 
@@ -200,9 +197,9 @@ When `q` is not provided, the results are for dry air.
 """
 @inline function specific_enthalpy(
     param_set::APS,
-    T::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
-) where {FT <: Real}
+    T,
+    q::PhasePartition = q_pt_0(param_set),
+)
     R_m = gas_constant_air(param_set, q)
     e_int = internal_energy(param_set, T, q)
     return e_int + R_m * T
@@ -222,11 +219,11 @@ and total specific humidity, given
 """
 @inline function specific_enthalpy_sat(
     param_set::APS,
-    T::FT,
-    ρ::FT,
-    q_tot::FT,
+    T,
+    ρ,
+    q_tot,
     ::Type{phase_type},
-) where {FT <: Real, phase_type <: ThermodynamicState}
+) where {phase_type <: ThermodynamicState}
     return specific_enthalpy(
         param_set,
         T,
@@ -302,10 +299,10 @@ When `q` is not provided, the results are for dry air.
 """
 @inline function total_specific_enthalpy(
     param_set::APS,
-    e_tot::FT,
-    T::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
-) where {FT <: Real}
+    e_tot,
+    T,
+    q::PhasePartition = q_pt_0(param_set),
+)
     R_m = gas_constant_air(param_set, q)
     return e_tot + R_m * T
 end
@@ -320,10 +317,6 @@ The total specific enthalpy, given
  - `R_m` [`gas_constant_air`](@ref)
  - `T` air temperature
 """
-@inline function total_specific_enthalpy(
-    e_tot::FT,
-    R_m::FT,
-    T::FT,
-) where {FT <: Real}
+@inline function total_specific_enthalpy(e_tot, R_m, T)
     return e_tot + R_m * T
 end

--- a/src/air_entropies.jl
+++ b/src/air_entropies.jl
@@ -15,12 +15,7 @@ The specific entropy, given
 
 The specific entropy is computed from equations (29)-(33) of [Pressel2015](@cite).
 """
-@inline function specific_entropy(
-    param_set::APS,
-    p::FT,
-    T::FT,
-    q::PhasePartition{FT},
-) where {FT <: Real}
+@inline function specific_entropy(param_set::APS, p, T, q::PhasePartition)
     L_v = latent_heat_vapor(param_set, T)
     L_s = latent_heat_sublim(param_set, T)
     s_d = specific_entropy_dry(param_set, p, T, q)
@@ -39,11 +34,11 @@ The dry air specific entropy, given
  - `q` phase partition
 """
 @inline function specific_entropy_dry(
-    param_set::APS,
-    p::FT,
-    T::FT,
-    q::PhasePartition{FT},
-) where {FT <: Real}
+    param_set::APS{FT},
+    p,
+    T,
+    q::PhasePartition,
+) where {FT}
     T_ref = TP.entropy_reference_temperature(param_set)
     p_ref = TP.MSLP(param_set)
     s_d_ref = TP.entropy_dry_air(param_set)
@@ -64,11 +59,11 @@ The specific entropy of water vapor, given
  - `q` phase partition
 """
 @inline function specific_entropy_vapor(
-    param_set::APS,
-    p::FT,
-    T::FT,
-    q::PhasePartition{FT},
-) where {FT <: Real}
+    param_set::APS{FT},
+    p,
+    T,
+    q::PhasePartition,
+) where {FT}
     T_ref = TP.entropy_reference_temperature(param_set)
     p_ref = TP.MSLP(param_set)
     s_v_ref = TP.entropy_water_vapor(param_set)

--- a/src/air_pressure_and_density.jl
+++ b/src/air_pressure_and_density.jl
@@ -21,10 +21,10 @@ When `q` is not provided, the results are for dry air.
 """
 @inline function air_pressure(
     param_set::APS,
-    T::FT,
-    ρ::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
-) where {FT <: Real}
+    T,
+    ρ,
+    q::PhasePartition = q_pt_0(param_set),
+)
     return gas_constant_air(param_set, q) * ρ * T
 end
 @inline air_pressure(param_set, T, ρ, q) =
@@ -47,10 +47,10 @@ When `q` is not provided, the results are for dry air.
 """
 @inline function air_density(
     param_set::APS,
-    T::FT,
-    p::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
-) where {FT <: Real}
+    T,
+    p,
+    q::PhasePartition = q_pt_0(param_set),
+)
     return p / (gas_constant_air(param_set, q) * T)
 end
 @inline air_density(param_set, T, p, q) =
@@ -73,11 +73,11 @@ When `q` is not provided, the results are for dry air.
 """
 @inline function exner(
     param_set::APS,
-    T::FT,
-    ρ::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
+    T,
+    ρ,
+    q::PhasePartition = q_pt_0(param_set),
     cpm = cp_m(param_set, q),
-) where {FT <: Real}
+)
     p = air_pressure(param_set, T, ρ, q)
     return exner_given_pressure(param_set, p, q, cpm)
 end
@@ -98,10 +98,10 @@ When `q` is not provided, the results are for dry air.
 """
 @inline function exner_given_pressure(
     param_set::APS,
-    p::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
+    p,
+    q::PhasePartition = q_pt_0(param_set),
     cpm = cp_m(param_set, q),
-) where {FT <: Real}
+)
     p0 = TP.p_ref_theta(param_set)
     # gas constant and isobaric specific heat of moist air
     _R_m = gas_constant_air(param_set, q)

--- a/src/air_properties.jl
+++ b/src/air_properties.jl
@@ -39,15 +39,12 @@ The specific gas constant of moist air, given
 
 When `q` is not provided, the results are for dry air.
 """
-@inline function gas_constant_air(
-    param_set::APS,
-    q::PhasePartition{FT},
-) where {FT}
+@inline function gas_constant_air(param_set::APS, q::PhasePartition)
     return gas_constant_air(param_set, q.tot, q.liq, q.ice)
 end
 
-@inline gas_constant_air(param_set::APS, ::Type{FT}) where {FT} =
-    gas_constant_air(param_set, q_pt_0(FT))
+@inline gas_constant_air(param_set::APS) =
+    gas_constant_air(param_set, q_pt_0(param_set))
 
 """
     cp_m(param_set, q_tot, q_liq, q_ice)
@@ -59,12 +56,7 @@ The isobaric specific heat capacity of moist air, given
  - `q_liq` specific humidity of liquid
  - `q_ice` specific humidity of ice
 """
-@inline function cp_m(
-    param_set::APS,
-    q_tot::FT,
-    q_liq::FT,
-    q_ice::FT,
-) where {FT <: Real}
+@inline function cp_m(param_set::APS, q_tot, q_liq, q_ice)
 
     cp_d = TP.cp_d(param_set)
     cp_v = TP.cp_v(param_set)
@@ -87,12 +79,11 @@ The isobaric specific heat capacity of moist air given
 
 When `q` is not provided, the results are for dry air.
 """
-@inline function cp_m(param_set::APS, q::PhasePartition{FT}) where {FT <: Real}
+@inline function cp_m(param_set::APS, q::PhasePartition)
     return cp_m(param_set, q.tot, q.liq, q.ice)
 end
 
-@inline cp_m(param_set::APS, ::Type{FT}) where {FT <: Real} =
-    cp_m(param_set, q_pt_0(FT))
+@inline cp_m(param_set::APS) = cp_m(param_set, q_pt_0(param_set))
 
 # TODO: The methods for cv_m do not parallel those for R_m and cp_m. Make consistent.
 """
@@ -103,7 +94,7 @@ The isochoric specific heat capacity of moist air, given
  - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `q` [`PhasePartition`](@ref). Without humidity argument, the results are for dry air.
 """
-@inline function cv_m(param_set::APS, q::PhasePartition{FT}) where {FT <: Real}
+@inline function cv_m(param_set::APS, q::PhasePartition)
     cv_d = TP.cv_d(param_set)
     cv_v = TP.cv_v(param_set)
     cv_l = TP.cv_l(param_set)
@@ -114,8 +105,7 @@ The isochoric specific heat capacity of moist air, given
            (cv_i - cv_v) * q.ice
 end
 
-@inline cv_m(param_set::APS, ::Type{FT}) where {FT <: Real} =
-    cv_m(param_set, q_pt_0(FT))
+@inline cv_m(param_set::APS) = cv_m(param_set, q_pt_0(param_set))
 
 # TODO remove gas_constants
 """
@@ -135,10 +125,7 @@ The function returns a tuple of
 
  This function is deprecated and will be removed in a future release.
 """
-@inline function gas_constants(
-    param_set::APS,
-    q::PhasePartition{FT},
-) where {FT <: Real}
+@inline function gas_constants(param_set::APS, q::PhasePartition)
     R_gas = gas_constant_air(param_set, q)
     cp = cp_m(param_set, q)
     cv = cv_m(param_set, q)
@@ -154,7 +141,7 @@ The specific latent heat of vaporization, given
  - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
 """
-@inline function latent_heat_vapor(param_set::APS, T::FT) where {FT <: Real}
+@inline function latent_heat_vapor(param_set::APS, T)
     cp_l = TP.cp_l(param_set)
     cp_v = TP.cp_v(param_set)
     LH_v0 = TP.LH_v0(param_set)
@@ -169,7 +156,7 @@ The specific latent heat of sublimation, given
  - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
 """
-@inline function latent_heat_sublim(param_set::APS, T::FT) where {FT <: Real}
+@inline function latent_heat_sublim(param_set::APS, T)
     LH_s0 = TP.LH_s0(param_set)
     cp_v = TP.cp_v(param_set)
     cp_i = TP.cp_i(param_set)
@@ -184,7 +171,7 @@ The specific latent heat of fusion, given
  - `param_set` an `AbstractParameterSet`, see the [`Thermodynamics`](@ref) for more details
  - `T` temperature
 """
-@inline function latent_heat_fusion(param_set::APS, T::FT) where {FT <: Real}
+@inline function latent_heat_fusion(param_set::APS, T)
     LH_f0 = TP.LH_f0(param_set)
     cp_l = TP.cp_l(param_set)
     cp_i = TP.cp_i(param_set)
@@ -203,12 +190,7 @@ capacities of the two phases, given
  - `LH_0` latent heat at the reference temperature `T_0`
  - `Δcp` difference in isobaric specific heat capacities between the two phases
 """
-@inline function latent_heat_generic(
-    param_set::APS,
-    T::FT,
-    LH_0::FT,
-    Δcp::FT,
-) where {FT <: Real}
+@inline function latent_heat_generic(param_set::APS, T, LH_0, Δcp)
     T_0 = TP.T_0(param_set)
     return LH_0 + Δcp * (T - T_0)
 end
@@ -225,11 +207,7 @@ liquid fraction `λ`, given
  - `T` air temperature
  - `λ` liquid fraction
 """
-@inline function latent_heat_mixed(
-    param_set::APS,
-    T::FT,
-    λ::FT,
-) where {FT <: Real}
+@inline function latent_heat_mixed(param_set::APS, T, λ)
     L_v = latent_heat_vapor(param_set, T)
     L_s = latent_heat_sublim(param_set, T)
     return λ * L_v + (1 - λ) * L_s
@@ -251,9 +229,9 @@ When `q` is not provided, the results are for dry air.
 """
 @inline function soundspeed_air(
     param_set::APS,
-    T::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
-) where {FT <: Real}
+    T,
+    q::PhasePartition = q_pt_0(param_set),
+)
     γ = cp_m(param_set, q) / cv_m(param_set, q)
     R_m = gas_constant_air(param_set, q)
     return sqrt(γ * R_m * T)

--- a/src/air_state_methods.jl
+++ b/src/air_state_methods.jl
@@ -274,10 +274,10 @@ The total energy per unit mass, given a thermodynamic state `ts`.
 """
 @inline function total_energy(
     param_set::APS,
-    ts::ThermodynamicState{FT},
-    e_kin::FT,
-    e_pot::FT,
-) where {FT <: Real}
+    ts::ThermodynamicState,
+    e_kin,
+    e_pot,
+)
     return internal_energy(param_set, ts) + e_pot + e_kin
 end
 
@@ -316,9 +316,9 @@ The total specific enthalpy, given a thermodynamic state `ts`.
 """
 @inline function total_specific_enthalpy(
     param_set::APS,
-    ts::ThermodynamicState{FT},
-    e_tot::FT,
-) where {FT <: Real}
+    ts::ThermodynamicState,
+    e_tot,
+)
     R_m = gas_constant_air(param_set, ts)
     T = air_temperature(param_set, ts)
     return total_specific_enthalpy(e_tot, R_m, T)
@@ -630,10 +630,7 @@ Partition the phases in equilibrium, returning a [`PhasePartition`](@ref) object
 
 Create a PhasePartition for dry air thermodynamic state.
 """
-@inline PhasePartition(
-    param_set::APS,
-    ts::AbstractPhaseDry{FT},
-) where {FT <: Real} = q_pt_0(FT)
+@inline PhasePartition(param_set::APS, ts::AbstractPhaseDry) = q_pt_0(param_set)
 
 """
     PhasePartition(param_set, ts::AbstractPhaseEquil)

--- a/src/air_states.jl
+++ b/src/air_states.jl
@@ -88,6 +88,8 @@ struct PhasePartition{FT <: Real}
     end
 end
 
+PhasePartition(tot, liq, ice) = PhasePartition(promote(tot, liq, ice)...)
+
 @inline Base.zero(::Type{PhasePartition{FT}}) where {FT} =
     PhasePartition(FT(0), FT(0), FT(0))
 
@@ -779,7 +781,7 @@ Base.convert(::Type{PhaseNonEquil{FT}}, ts::PhaseNonEquil) where {FT} =
     param_set::APS,
     e_int::FT,
     ρ::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
+    q::PhasePartition = q_pt_0(param_set),
 ) where {FT}
     return PhaseNonEquil{FT}(e_int, ρ, q)
 end

--- a/src/air_temperatures.jl
+++ b/src/air_temperatures.jl
@@ -22,10 +22,10 @@ When `q` is not provided, the results are for dry air.
 """
 @inline function air_temperature(
     param_set::APS,
-    e_int::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
-    cvm = cv_m(param_set, q),
-) where {FT <: Real}
+    e_int,
+    q::PhasePartition = q_pt_0(param_set),
+    cvm::Number = cv_m(param_set, q),
+)
     T_0 = TP.T_0(param_set)
     R_d = TP.R_d(param_set)
     e_int_v0 = TP.e_int_v0(param_set)
@@ -54,9 +54,9 @@ When `q` is not provided, the results are for dry air.
 """
 @inline function air_temperature_from_enthalpy(
     param_set::APS,
-    h::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
-) where {FT <: Real}
+    h,
+    q::PhasePartition = q_pt_0(param_set),
+)
     cp_m_ = cp_m(param_set, q)
     T_0 = TP.T_0(param_set)
     LH_v0 = TP.LH_v0(param_set)
@@ -81,10 +81,10 @@ When `q` is not provided, the results are for dry air.
 """
 @inline function air_temperature_given_ρp(
     param_set::APS,
-    p::FT,
-    ρ::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
-) where {FT <: Real}
+    p,
+    ρ,
+    q::PhasePartition = q_pt_0(param_set),
+)
     R_m = gas_constant_air(param_set, q)
     return p / (R_m * ρ)
 end
@@ -106,11 +106,11 @@ When `q` is not provided, the results are for dry air.
 """
 @inline function dry_pottemp(
     param_set::APS,
-    T::FT,
-    ρ::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
+    T,
+    ρ,
+    q::PhasePartition = q_pt_0(param_set),
     cpm = cp_m(param_set, q),
-) where {FT <: Real}
+)
     return T / exner(param_set, T, ρ, q, cpm)
 end
 
@@ -132,11 +132,11 @@ When `q` is not provided, the results are for dry air, i.e., using the adiabatic
 """
 @inline function dry_pottemp_given_pressure(
     param_set::APS,
-    T::FT,
-    p::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
+    T,
+    p,
+    q::PhasePartition = q_pt_0(param_set),
     cpm = cp_m(param_set, q),
-) where {FT <: Real}
+)
     return T / exner_given_pressure(param_set, p, q, cpm)
 end
 
@@ -154,8 +154,8 @@ When `q` is not provided, `latent_heat_liq_ice` is zero.
 """
 @inline function latent_heat_liq_ice(
     param_set::APS,
-    q::PhasePartition{FT} = q_pt_0(FT),
-) where {FT <: Real}
+    q::PhasePartition = q_pt_0(param_set),
+)
     LH_v0 = TP.LH_v0(param_set)
     LH_s0 = TP.LH_s0(param_set)
     return LH_v0 * q.liq + LH_s0 * q.ice
@@ -177,11 +177,11 @@ When `q` is not provided, the result is the dry-air potential temperature.
 """
 @inline function liquid_ice_pottemp_given_pressure(
     param_set::APS,
-    T::FT,
-    p::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
+    T,
+    p,
+    q::PhasePartition = q_pt_0(param_set),
     cpm = cp_m(param_set, q),
-) where {FT <: Real}
+)
     # liquid-ice potential temperature, approximating latent heats
     # of phase transitions as constants
     return dry_pottemp_given_pressure(param_set, T, p, q, cpm) *
@@ -205,11 +205,11 @@ When `q` is not provided, the result is the dry-air potential temperature.
 """
 @inline function liquid_ice_pottemp(
     param_set::APS,
-    T::FT,
-    ρ::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
+    T,
+    ρ,
+    q::PhasePartition = q_pt_0(param_set),
     cpm = cp_m(param_set, q),
-) where {FT <: Real}
+)
     return liquid_ice_pottemp_given_pressure(
         param_set,
         T,
@@ -240,11 +240,11 @@ When `q` is not provided, the `θ_liq_ice` is assumed to be the dry-air potentia
 """
 @inline function air_temperature_given_pθq(
     param_set::APS,
-    p::FT,
-    θ_liq_ice::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
+    p,
+    θ_liq_ice,
+    q::PhasePartition = q_pt_0(param_set),
     cpm = cp_m(param_set, q),
-) where {FT <: Real}
+)
     return θ_liq_ice * exner_given_pressure(param_set, p, q, cpm) +
            latent_heat_liq_ice(param_set, q) / cpm
 end
@@ -266,10 +266,10 @@ When `q` is not provided, the results are for dry air.
 """
 @inline function air_temperature_given_ρθq(
     param_set::APS,
-    ρ::FT,
-    θ_liq_ice::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
-) where {FT <: Real}
+    ρ,
+    θ_liq_ice,
+    q::PhasePartition = q_pt_0(param_set),
+)
 
     p0 = TP.p_ref_theta(param_set)
     cvm = cv_m(param_set, q)
@@ -300,12 +300,12 @@ When `q` is not provided, the air assumed to be dry.
 """
 @inline function liquid_ice_pottemp_sat(
     param_set::APS,
-    T::FT,
-    ρ::FT,
+    T,
+    ρ,
     ::Type{phase_type},
-    q::PhasePartition{FT} = q_pt_0(FT),
+    q::PhasePartition = q_pt_0(param_set),
     cpm = cp_m(param_set, q),
-) where {FT <: Real, phase_type <: ThermodynamicState}
+) where {phase_type <: ThermodynamicState}
     q_v_sat = q_vap_saturation(param_set, T, ρ, phase_type, q)
     return liquid_ice_pottemp(param_set, T, ρ, PhasePartition(q_v_sat), cpm)
 end
@@ -323,11 +323,11 @@ The saturated liquid ice potential temperature, given
 """
 @inline function liquid_ice_pottemp_sat(
     param_set::APS,
-    T::FT,
-    ρ::FT,
+    T,
+    ρ,
     ::Type{phase_type},
-    q_tot::FT,
-) where {FT <: Real, phase_type <: ThermodynamicState}
+    q_tot,
+) where {phase_type <: ThermodynamicState}
     q = PhasePartition_equil(param_set, T, ρ, q_tot, phase_type)
     cpm = cp_m(param_set, q)
     return liquid_ice_pottemp(param_set, T, ρ, q, cpm)
@@ -354,11 +354,11 @@ have the same density as the moist air parcel at the same pressure.
 """
 @inline function virtual_pottemp(
     param_set::APS,
-    T::FT,
-    ρ::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
+    T,
+    ρ,
+    q::PhasePartition = q_pt_0(param_set),
     cpm = cp_m(param_set, q),
-) where {FT <: Real}
+)
     R_d = TP.R_d(param_set)
     return gas_constant_air(param_set, q) / R_d *
            dry_pottemp(param_set, T, ρ, q, cpm)
@@ -384,9 +384,9 @@ at the same pressure.
 """
 @inline function virtual_temperature(
     param_set::APS,
-    T::FT,
-    q::PhasePartition{FT} = q_pt_0(FT),
-) where {FT <: Real}
+    T,
+    q::PhasePartition = q_pt_0(param_set),
+)
     R_d = TP.R_d(param_set)
     return gas_constant_air(param_set, q) / R_d * T
 end
@@ -403,14 +403,14 @@ The air temperature and total specific humidity `q_tot`, given
  - `phase_type` a thermodynamic state type
 """
 @inline function temperature_and_humidity_given_TᵥρRH(
-    param_set::APS,
-    T_virt::FT,
-    ρ::FT,
-    RH::FT,
+    param_set::APS{FT},
+    T_virt,
+    ρ,
+    RH,
     ::Type{phase_type},
     maxiter::Int = 100,
-    tol::RS.AbstractTolerance = RS.ResidualTolerance{FT}(sqrt(eps(FT))),
-) where {FT <: Real, phase_type <: ThermodynamicState}
+    tol::RS.AbstractTolerance = RS.ResidualTolerance(sqrt(eps(FT))),
+) where {FT, phase_type <: ThermodynamicState}
 
     T_init_min = TP.T_init_min(param_set)
     _T_max = T_virt
@@ -473,12 +473,12 @@ The temperature `T` is found by finding the root of
 """
 @inline function air_temperature_given_ρθq_nonlinear(
     param_set::APS,
-    ρ::FT,
-    θ_liq_ice::FT,
+    ρ,
+    θ_liq_ice,
     maxiter::Int,
     tol::RS.AbstractTolerance,
-    q::PhasePartition{FT} = q_pt_0(FT),
-) where {FT <: Real}
+    q::PhasePartition = q_pt_0(param_set),
+)
     T_init_min = TP.T_init_min(param_set)
     _T_max = TP.T_max(param_set)
     @inline roots(T) =

--- a/src/config_numerical_method.jl
+++ b/src/config_numerical_method.jl
@@ -6,12 +6,12 @@
 @inline function sa_numerical_method(
     ::Type{NM},
     param_set::APS,
-    ρ::FT,
-    e_int::FT,
-    q_tot::FT,
+    ρ,
+    e_int,
+    q_tot,
     ::Type{phase_type},
-    T_guess::Union{FT, Nothing},
-) where {FT, NM <: RS.NewtonsMethod, phase_type <: PhaseEquil}
+    T_guess,
+) where {NM <: RS.NewtonsMethod, phase_type <: PhaseEquil}
     T_init_min = TP.T_init_min(param_set)
     T_init = if T_guess isa Nothing
         max(T_init_min, air_temperature(param_set, e_int, PhasePartition(q_tot))) # Assume all vapor
@@ -24,12 +24,12 @@ end
 @inline function sa_numerical_method(
     ::Type{NM},
     param_set::APS,
-    ρ::FT,
-    e_int::FT,
-    q_tot::FT,
+    ρ,
+    e_int,
+    q_tot,
     ::Type{phase_type},
-    T_guess::Union{FT, Nothing},
-) where {FT, NM <: RS.NewtonsMethodAD, phase_type <: PhaseEquil}
+    T_guess,
+) where {NM <: RS.NewtonsMethodAD, phase_type <: PhaseEquil}
     T_init_min = TP.T_init_min(param_set)
     T_init = if T_guess isa Nothing
         max(T_init_min, air_temperature(param_set, e_int, PhasePartition(q_tot))) # Assume all vapor
@@ -43,10 +43,10 @@ end
     ::Type{NM},
     param_set::APS,
     ρ::FT,
-    e_int::FT,
-    q_tot::FT,
+    e_int,
+    q_tot,
     ::Type{phase_type},
-    T_guess::Union{FT, Nothing},
+    T_guess,
 ) where {FT, NM <: RS.SecantMethod, phase_type <: PhaseEquil}
     T_init_min = TP.T_init_min(param_set)
     q_pt = PhasePartition(q_tot, FT(0), q_tot) # Assume all ice
@@ -63,10 +63,10 @@ end
     ::Type{NM},
     param_set::APS,
     ρ::FT,
-    e_int::FT,
-    q_tot::FT,
+    e_int,
+    q_tot,
     ::Type{phase_type},
-    T_guess::Union{FT, Nothing},
+    T_guess,
 ) where {FT, NM <: RS.RegulaFalsiMethod, phase_type <: PhaseEquil}
     T_init_min = TP.T_init_min(param_set)
     q_pt = PhasePartition(q_tot, FT(0), q_tot) # Assume all ice
@@ -86,12 +86,12 @@ end
 @inline function sa_numerical_method_ρpq(
     ::Type{NM},
     param_set::APS,
-    ρ::FT,
-    p::FT,
-    q_tot::FT,
+    ρ,
+    p,
+    q_tot,
     ::Type{phase_type},
-    T_guess::Union{FT, Nothing},
-) where {FT, NM <: RS.NewtonsMethodAD, phase_type <: PhaseEquil}
+    T_guess,
+) where {NM <: RS.NewtonsMethodAD, phase_type <: PhaseEquil}
     q_pt = PhasePartition(q_tot)
     T_init = if T_guess isa Nothing
         air_temperature_given_ρp(param_set, p, ρ, q_pt)
@@ -104,12 +104,12 @@ end
 @inline function sa_numerical_method_ρpq(
     ::Type{NM},
     param_set::APS,
-    ρ::FT,
-    p::FT,
-    q_tot::FT,
+    ρ,
+    p,
+    q_tot,
     ::Type{phase_type},
-    T_guess::Union{FT, Nothing},
-) where {FT, NM <: RS.RegulaFalsiMethod, phase_type <: PhaseEquil}
+    T_guess,
+) where {NM <: RS.RegulaFalsiMethod, phase_type <: PhaseEquil}
     q_pt = PhasePartition(q_tot)
     T_1 = air_temperature_given_ρp(param_set, p, ρ, q_pt) - 5
     T_2 = air_temperature_given_ρp(param_set, p, ρ, q_pt) + 5
@@ -123,12 +123,12 @@ end
 @inline function sa_numerical_method_peq(
     ::Type{NM},
     param_set::APS,
-    p::FT,
-    e_int::FT,
-    q_tot::FT,
+    p,
+    e_int,
+    q_tot,
     ::Type{phase_type},
-    T_guess::Union{FT, Nothing},
-) where {FT, NM <: RS.NewtonsMethodAD, phase_type <: PhaseEquil}
+    T_guess,
+) where {NM <: RS.NewtonsMethodAD, phase_type <: PhaseEquil}
     T_init_min = TP.T_init_min(param_set)
     T_init = if T_guess isa Nothing
         max(T_init_min, air_temperature(param_set, e_int, PhasePartition(q_tot))) # Assume all vapor
@@ -142,10 +142,10 @@ end
     ::Type{NM},
     param_set::APS,
     p::FT,
-    e_int::FT,
-    q_tot::FT,
+    e_int,
+    q_tot,
     ::Type{phase_type},
-    T_guess::Union{FT, Nothing},
+    T_guess,
 ) where {FT, NM <: RS.SecantMethod, phase_type <: PhaseEquil}
     T_init_min = TP.T_init_min(param_set)
     q_pt = PhasePartition(q_tot, FT(0), q_tot) # Assume all ice
@@ -165,12 +165,12 @@ end
 @inline function sa_numerical_method_phq(
     ::Type{NM},
     param_set::APS,
-    p::FT,
-    h::FT,
-    q_tot::FT,
+    p,
+    h,
+    q_tot,
     ::Type{phase_type},
-    T_guess::Union{FT, Nothing},
-) where {FT, NM <: RS.NewtonsMethodAD, phase_type <: PhaseEquil}
+    T_guess,
+) where {NM <: RS.NewtonsMethodAD, phase_type <: PhaseEquil}
     T_init_min = TP.T_init_min(param_set)
     T_init = if T_guess isa Nothing # Assume all vapor
         max(
@@ -187,10 +187,10 @@ end
     ::Type{NM},
     param_set::APS,
     p::FT,
-    h::FT,
-    q_tot::FT,
+    h,
+    q_tot,
     ::Type{phase_type},
-    T_guess::Union{FT, Nothing},
+    T_guess,
 ) where {FT, NM <: RS.SecantMethod, phase_type <: PhaseEquil}
     T_init_min = TP.T_init_min(param_set)
     q_pt = PhasePartition(q_tot, FT(0), q_tot) # Assume all ice
@@ -207,10 +207,10 @@ end
     ::Type{NM},
     param_set::APS,
     p::FT,
-    h::FT,
-    q_tot::FT,
+    h,
+    q_tot,
     ::Type{phase_type},
-    T_guess::Union{FT, Nothing},
+    T_guess,
 ) where {FT, NM <: RS.RegulaFalsiMethod, phase_type <: PhaseEquil}
     T_init_min = TP.T_init_min(param_set)
     q_pt = PhasePartition(q_tot, FT(0), q_tot) # Assume all ice
@@ -230,12 +230,12 @@ end
 @inline function sa_numerical_method_pθq(
     ::Type{NM},
     param_set::APS,
-    p::FT,
-    θ_liq_ice::FT,
-    q_tot::FT,
+    p,
+    θ_liq_ice,
+    q_tot,
     ::Type{phase_type},
-    T_guess::Union{FT, Nothing},
-) where {FT, NM <: RS.RegulaFalsiMethod, phase_type <: PhaseEquil}
+    T_guess,
+) where {NM <: RS.RegulaFalsiMethod, phase_type <: PhaseEquil}
     _T_init_min = TP.T_init_min(param_set)
     _T_max = TP.T_max(param_set)
     @inline air_temp(q) = air_temperature_given_pθq(param_set, p, θ_liq_ice, q)
@@ -249,10 +249,10 @@ end
     ::Type{NM},
     param_set::APS,
     p::FT,
-    θ_liq_ice::FT,
-    q_tot::FT,
+    θ_liq_ice,
+    q_tot,
     ::Type{phase_type},
-    T_guess::Union{FT, Nothing},
+    T_guess,
 ) where {FT, NM <: RS.SecantMethod, phase_type <: PhaseEquil}
     _T_init_min = TP.T_init_min(param_set)
     @inline air_temp(q) = air_temperature_given_pθq(param_set, p, θ_liq_ice, q)
@@ -265,12 +265,12 @@ end
 @inline function sa_numerical_method_pθq(
     ::Type{NM},
     param_set::APS,
-    p::FT,
-    θ_liq_ice::FT,
-    q_tot::FT,
+    p,
+    θ_liq_ice,
+    q_tot,
     ::Type{phase_type},
-    T_guess::Union{FT, Nothing},
-) where {FT, NM <: RS.NewtonsMethodAD, phase_type <: PhaseEquil}
+    T_guess,
+) where {NM <: RS.NewtonsMethodAD, phase_type <: PhaseEquil}
     T_init_min = TP.T_init_min(param_set)
     @inline air_temp(q) = air_temperature_given_pθq(param_set, p, θ_liq_ice, q)
     T_init = if T_guess isa Nothing

--- a/src/saturation_adjustment.jl
+++ b/src/saturation_adjustment.jl
@@ -34,14 +34,14 @@ It is the most common entry point for saturation adjustment.
 @inline function saturation_adjustment(
     ::Type{sat_adjust_method},
     param_set::APS,
-    e_int::FT,
-    ρ::FT,
-    q_tot::FT,
+    e_int,
+    ρ,
+    q_tot,
     ::Type{phase_type},
     maxiter::Int,
     relative_temperature_tol::Real,
-    T_guess::Union{FT, Nothing} = nothing,
-) where {FT <: Real, sat_adjust_method, phase_type <: PhaseEquil}
+    T_guess = nothing,
+) where {sat_adjust_method, phase_type <: PhaseEquil}
     _T_min = TP.T_min(param_set)
     tol = RS.RelativeSolutionTolerance(relative_temperature_tol)
 
@@ -111,14 +111,14 @@ See also [`saturation_adjustment`](@ref).
 @inline function saturation_adjustment_given_peq(
     ::Type{sat_adjust_method},
     param_set::APS,
-    p::FT,
-    e_int::FT,
-    q_tot::FT,
+    p,
+    e_int,
+    q_tot,
     ::Type{phase_type},
     maxiter::Int,
     relative_temperature_tol::Real,
-    T_guess::Union{FT, Nothing} = nothing,
-) where {FT <: Real, sat_adjust_method, phase_type <: PhaseEquil}
+    T_guess = nothing,
+) where {sat_adjust_method, phase_type <: PhaseEquil}
     # Define how to compute saturated internal energy given p
     @inline e_int_sat_given_p(T, param_set, p, q_tot, phase_type) =
         internal_energy_sat(
@@ -171,14 +171,14 @@ See also [`saturation_adjustment`](@ref).
 @inline function saturation_adjustment_given_phq(
     ::Type{sat_adjust_method},
     param_set::APS,
-    p::FT,
-    h::FT,
-    q_tot::FT,
+    p,
+    h,
+    q_tot,
     ::Type{phase_type},
     maxiter::Int,
     relative_temperature_tol::Real,
-    T_guess::Union{FT, Nothing} = nothing,
-) where {FT <: Real, sat_adjust_method, phase_type <: PhaseEquil}
+    T_guess = nothing,
+) where {sat_adjust_method, phase_type <: PhaseEquil}
     # Define how to compute saturated enthalpy given p
     @inline h_sat_given_p(T, param_set, p, q_tot, phase_type) =
         specific_enthalpy_sat(
@@ -232,14 +232,14 @@ See also [`saturation_adjustment`](@ref).
 @inline function saturation_adjustment_ρpq(
     ::Type{sat_adjust_method},
     param_set::APS,
-    ρ::FT,
-    p::FT,
-    q_tot::FT,
+    ρ,
+    p,
+    q_tot,
     ::Type{phase_type},
     maxiter::Int,
     relative_temperature_tol::Real,
-    T_guess::Union{FT, Nothing} = nothing,
-) where {FT <: Real, sat_adjust_method, phase_type <: PhaseEquil}
+    T_guess = nothing,
+) where {sat_adjust_method, phase_type <: PhaseEquil}
     tol = RS.RelativeSolutionTolerance(relative_temperature_tol)
     # Use `oftype` to preserve diagonalized type signatures:
     @inline roots(T) =
@@ -299,15 +299,15 @@ It uses the `SecantMethod`.
 See also [`saturation_adjustment`](@ref).
 """
 @inline function saturation_adjustment_given_ρθq(
-    param_set::APS,
-    ρ::FT,
-    θ_liq_ice::FT,
-    q_tot::FT,
+    param_set::APS{FT},
+    ρ,
+    θ_liq_ice,
+    q_tot,
     ::Type{phase_type},
     maxiter::Int,
     tol::RS.AbstractTolerance,
-    T_guess::Union{FT, Nothing} = nothing,
-) where {FT <: Real, phase_type <: PhaseEquil}
+    T_guess = nothing,
+) where {FT, phase_type <: PhaseEquil}
     # Define the specific functions for this saturation adjustment method
     @inline T_1_func(q_pt) =
         air_temperature_given_ρθq(param_set, ρ, θ_liq_ice, q_pt)
@@ -369,14 +369,14 @@ See also [`saturation_adjustment`](@ref).
 @inline function saturation_adjustment_given_pθq(
     ::Type{sat_adjust_method},
     param_set::APS,
-    p::FT,
-    θ_liq_ice::FT,
-    q_tot::FT,
+    p,
+    θ_liq_ice,
+    q_tot,
     ::Type{phase_type},
     maxiter::Int,
     relative_temperature_tol::Real,
-    T_guess::Union{FT, Nothing} = nothing,
-) where {FT <: Real, sat_adjust_method, phase_type <: PhaseEquil}
+    T_guess = nothing,
+) where {sat_adjust_method, phase_type <: PhaseEquil}
     tol = RS.RelativeSolutionTolerance(relative_temperature_tol)
 
     # Define the specific functions for this saturation adjustment method
@@ -437,28 +437,14 @@ end
 ### Helper functions ###
 
 """
-    ΔT_min(::Type{FT})
-
-Minimum temperature interval for the Secant method bracketing.
-"""
-@inline ΔT_min(::Type{FT}) where {FT} = FT(3)
-
-"""
-    ΔT_max(::Type{FT})
-
-Maximum temperature interval for the Secant method bracketing.
-"""
-@inline ΔT_max(::Type{FT}) where {FT} = FT(10)
-
-"""
     bound_upper_temperature(T_1, T_2)
 
 Bounds the upper temperature guess `T_2` for the Secant method
 to prevent divergence.
 """
-@inline function bound_upper_temperature(T_1::FT, T_2::FT) where {FT <: Real}
-    T_2 = max(T_1 + ΔT_min(FT), T_2)
-    return min(T_1 + ΔT_max(FT), T_2)
+@inline function bound_upper_temperature(T_1, T_2)
+    T_2 = max(T_1 + 3, T_2)
+    return min(T_1 + 10, T_2)
 end
 
 """
@@ -531,9 +517,9 @@ pressure-based saturation adjustment methods.
 @inline function _saturation_adjustment_p_thermo_q(
     sat_method,
     param_set::APS,
-    p::FT,
-    thermo_var::FT, # This can be e_int or h
-    q_tot::FT,
+    p,
+    thermo_var, # This can be e_int or h
+    q_tot,
     ::Type{phase_type},
     maxiter,
     relative_temperature_tol,
@@ -544,7 +530,7 @@ pressure-based saturation adjustment methods.
     numerical_method_constructor,
     warning_func,
     warning_args...,
-) where {FT <: Real, phase_type <: PhaseEquil}
+) where {phase_type <: PhaseEquil}
     _T_min = TP.T_min(param_set)
     tol = RS.RelativeSolutionTolerance(relative_temperature_tol)
 
@@ -615,8 +601,8 @@ It encapsulates the common workflow for both pressure-based (`pθq`) and density
 """
 @inline function _saturation_adjustment_θ_q_kernel(
     param_set::APS,
-    θ_liq_ice::FT,
-    q_tot::FT,
+    θ_liq_ice,
+    q_tot,
     ::Type{phase_type},
     maxiter::Int,
     tol::RS.AbstractTolerance,
@@ -627,7 +613,7 @@ It encapsulates the common workflow for both pressure-based (`pθq`) and density
     numerical_method_constructor,
     warning_func,
     warning_args...,
-) where {FT <: Real, phase_type <: PhaseEquil}
+) where {phase_type <: PhaseEquil}
     _T_min = TP.T_min(param_set)
 
     # 1. Unsaturated Check (logic is now generic)
@@ -659,11 +645,11 @@ Note that the `e_int` argument is a placeholder for interface consistency
 and is not used.
 """
 @inline function ∂e_int_∂T(
-    param_set::APS,
-    T::FT,
-    e_int::FT,
-    ρ::FT,
-    q_tot::FT,
+    param_set::APS{FT},
+    T,
+    e_int,
+    ρ,
+    q_tot,
     ::Type{phase_type},
     λ = liquid_fraction(param_set, T, phase_type),
     p_vap_sat = saturation_vapor_pressure(
@@ -675,7 +661,7 @@ and is not used.
     ),
     q = PhasePartition_equil(param_set, T, ρ, q_tot, p_vap_sat, λ),
     cvm = cv_m(param_set, q),
-) where {FT <: Real, phase_type <: PhaseEquil}
+) where {FT, phase_type <: PhaseEquil}
     T_0 = TP.T_0(param_set)
     cv_v = TP.cv_v(param_set)
     cv_l = TP.cv_l(param_set)
@@ -708,12 +694,12 @@ temperature at saturation, for use in Newton's method. It computes all necessary
 intermediate variables.
 """
 @inline function ∂e_int_∂T_sat(
-    param_set::APS,
-    T::FT,
-    ρ::FT,
-    q_tot::FT,
+    param_set::APS{FT},
+    T,
+    ρ,
+    q_tot,
     ::Type{phase_type},
-) where {FT <: Real, phase_type <: PhaseEquil}
+) where {FT, phase_type <: PhaseEquil}
     λ = liquid_fraction(param_set, T, phase_type)
     p_vap_sat = saturation_vapor_pressure(
         param_set,
@@ -760,11 +746,11 @@ It is computed either given
 """
 @inline function ∂q_vap_sat_∂T(
     param_set::APS,
-    λ::FT,
-    T::FT,
-    q_vap_sat::FT,
+    λ,
+    T,
+    q_vap_sat,
     L = latent_heat_mixed(param_set, T, λ),
-) where {FT <: Real}
+)
     R_v = TP.R_v(param_set)
     return q_vap_sat * (L / (R_v * T^2) - 1 / T)
 end
@@ -784,11 +770,11 @@ relative humidity `RH`.
 """
 @inline function virt_temp_from_RH(
     param_set::APS,
-    T::FT,
-    ρ::FT,
-    RH::FT,
+    T,
+    ρ,
+    RH,
     ::Type{phase_type},
-) where {FT <: Real, phase_type <: ThermodynamicState}
+) where {phase_type <: ThermodynamicState}
     q_tot = RH * q_vap_saturation(param_set, T, ρ, phase_type)
     q_pt = PhasePartition_equil(param_set, T, ρ, q_tot, phase_type)
     return virtual_temperature(param_set, T, q_pt)

--- a/test/correctness.jl
+++ b/test/correctness.jl
@@ -74,21 +74,21 @@ This file contains tests for fundamental thermodynamic relations and physical la
         @test gas_constant_air(param_set, PhasePartition(FT(1))) === _R_v
         @test gas_constant_air(param_set, PhasePartition(FT(0.5), FT(0.5))) ≈
               _R_d / 2
-        @test gas_constant_air(param_set, FT) == _R_d
+        @test gas_constant_air(param_set) == _R_d
 
         # Test specific heat capacities for different phases
         @test cp_m(param_set, PhasePartition(FT(0))) === _cp_d
         @test cp_m(param_set, PhasePartition(FT(1))) === _cp_v
         @test cp_m(param_set, PhasePartition(FT(1), FT(1))) === _cp_l
         @test cp_m(param_set, PhasePartition(FT(1), FT(0), FT(1))) === _cp_i
-        @test cp_m(param_set, FT) == _cp_d
+        @test cp_m(param_set) == _cp_d
 
         # Test specific heat capacities at constant volume
         @test cv_m(param_set, PhasePartition(FT(0))) === _cp_d - _R_d
         @test cv_m(param_set, PhasePartition(FT(1))) === _cp_v - _R_v
         @test cv_m(param_set, PhasePartition(FT(1), FT(1))) === _cv_l
         @test cv_m(param_set, PhasePartition(FT(1), FT(0), FT(1))) === _cv_i
-        @test cv_m(param_set, FT) == _cv_d
+        @test cv_m(param_set) == _cv_d
     end
 
     @testset "Speed of sound" begin


### PR DESCRIPTION
Removes dispatch on FT for dual number support that is required by automatic differentiation.