### PR TITLE
Fix NewtonsMethodAD

### DIFF
--- a/src/config_numerical_method.jl
+++ b/src/config_numerical_method.jl
@@ -28,7 +28,7 @@ end
     e_int::FT,
     q_tot::FT,
     ::Type{phase_type},
-    T_guess::FT,
+    T_guess::Union{FT, Nothing},
 ) where {FT, NM <: RS.NewtonsMethodAD, phase_type <: PhaseEquil}
     T_init_min = TP.T_init_min(param_set)
     T_init = if T_guess isa Nothing

--- a/src/saturation_adjustment.jl
+++ b/src/saturation_adjustment.jl
@@ -57,12 +57,13 @@ It is the most common entry point for saturation adjustment.
         e_int_sat_val = internal_energy_sat(param_set, T, ρ, q_tot, phase_type)
         f = e_int_sat_val - e_int
 
-        # This compile-time branch makes this function difficult to merge with others
-        return ifelse(
-            sat_adjust_method <: RS.NewtonsMethod,
-            (f, ∂e_int_∂T_sat(param_set, T, ρ, q_tot, phase_type)),
-            f,
-        )
+        # NewtonsMethod needs to return the derivative but other methods don't, 
+        # which makes this function difficult to merge with others
+        if sat_adjust_method <: RS.NewtonsMethod
+            return (f, ∂e_int_∂T_sat(param_set, T, ρ, q_tot, phase_type))
+        else
+            return f
+        end
     end
 
     numerical_method = sa_numerical_method(

--- a/test/miscellaneous.jl
+++ b/test/miscellaneous.jl
@@ -42,6 +42,15 @@ This file contains various miscellaneous tests including ProfileSet Iterator, Ba
                 RS.NewtonsMethod,
                 T_guess,
             )
+        ts =
+            PhaseEquil_ρeq.(
+                param_set,
+                ρ,
+                e_int,
+                args...,
+                RS.NewtonsMethodAD,
+                T_guess,
+            )
         ts = PhaseEquil_ρθq.(param_set, ρ, θ_liq_ice, args..., T_guess)
         ts =
             PhaseEquil_peq.(


### PR DESCRIPTION
Fixes a bug in saturation adjustment with NewtonsMethodAD. I added a test in `test/miscellaneous.jl` because the test profiles in `test/default behavior accuracy.jl` don't converge with NewtonsMethodAD. We should revisit whether the profiles are physical.