### PR TITLE
Release v1.3.0 instead of v1.2.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ Thermodynamics.jl Release Notes
 main
 --------
 
-v1.2.3
+v1.3.0
 --------
 
 ### Saturation adjustment: correctness fixes (changes model output)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Thermodynamics"
 uuid = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
 authors = ["Climate Modeling Alliance"]
-version = "1.2.3"
+version = "1.3.0"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"


### PR DESCRIPTION
## Why

v1.2.3 never made it into the General registry, which is why no GitHub release appeared. [JuliaRegistries/General#164116](https://github.com/JuliaRegistries/General/pull/164116) is still open because AutoMerge rejected it:

> A patch release is not allowed to narrow the supported ranges of Julia versions. The ranges have changed from `VersionRange("1.6.0 - 1")` (in 1.2.2) to `VersionRange("1.10.0 - 1")` (in 1.2.3).

PR #348 bumped the version to 1.2.3 and raised `julia` compat from `1.6` to `1.10` in the same commit. Since the registry PR never merged, `JuliaTagBot` never posted its trigger comment and every TagBot workflow run was skipped.

## What this does

Renumbers the release to v1.3.0 in `Project.toml` and `NEWS.md`. A raised minimum Julia version warrants a minor bump anyway, and AutoMerge only applies the narrowing guideline to patch releases. No code changes.

The stale hand-made `v1.2.3` git tag will be deleted and Registrator retriggered once this merges; General#164116 will be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)